### PR TITLE
Add consumers and event messaging for Auction lifecycle

### DIFF
--- a/Carsties/Carsties.sln
+++ b/Carsties/Carsties.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuctionService", "src\Aucti
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchService", "src\SearchService\SearchService.csproj", "{301CD37E-DCC2-4478-A6AD-5BF3B9A19E7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contracts", "src\Contracts\Contracts.csproj", "{455A4B02-9551-48F9-8A94-12472E23DC70}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,9 +28,14 @@ Global
 		{301CD37E-DCC2-4478-A6AD-5BF3B9A19E7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{301CD37E-DCC2-4478-A6AD-5BF3B9A19E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{301CD37E-DCC2-4478-A6AD-5BF3B9A19E7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{455A4B02-9551-48F9-8A94-12472E23DC70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{455A4B02-9551-48F9-8A94-12472E23DC70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{455A4B02-9551-48F9-8A94-12472E23DC70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{455A4B02-9551-48F9-8A94-12472E23DC70}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E1ACFA20-5AC1-4071-9B6C-6EBBAD952913} = {141D36BB-AD7D-42A8-86ED-5CCD74033B4E}
 		{301CD37E-DCC2-4478-A6AD-5BF3B9A19E7F} = {141D36BB-AD7D-42A8-86ED-5CCD74033B4E}
+		{455A4B02-9551-48F9-8A94-12472E23DC70} = {141D36BB-AD7D-42A8-86ED-5CCD74033B4E}
 	EndGlobalSection
 EndGlobal

--- a/Carsties/README.md
+++ b/Carsties/README.md
@@ -221,3 +221,31 @@ bash-5.2$ docker-compose up -d
 ✔ Container carsties-mongodb-1   Started                                                                                                                                                                                  0.6s
 ✔ Container carsties-postgres-1  Running      
 ```
+
+
+```javascript
+ Carsties   main ≡  ?1 ~5    dotnet new classlib -o src/Contracts
+The template "Class Library" was created successfully.
+
+Processing post-creation actions...
+Restoring /Users/oscarlagatta/Documents/sandbox/demo/Carsties/src/Contracts/Contracts.csproj:
+  Determining projects to restore...
+  Restored /Users/oscarlagatta/Documents/sandbox/demo/Carsties/src/Contracts/Contracts.csproj (in 27 ms).
+Restore succeeded.
+
+
+  Carsties   main ≡  ?2 ~5    dotnet sln add src/Contracts
+
+Project `src/Contracts/Contracts.csproj` added to the solution.
+  Carsties   main ≡  ?2 ~6    
+  Carsties   main ≡  ?2 ~6    cd src   
+  src   main ≡  ?2 ~6    cd AuctionService 
+  AuctionService   main ≡  ?2 ~6    dotnet add reference ../../src/Contracts 
+Reference `..\Contracts\Contracts.csproj` added to the project.
+  AuctionService   main ≡  ?2 ~6    cd ..
+  src   main ≡  ?2 ~6    cd SearchService 
+  SearchService   main ≡  ?2 ~6    dotnet add reference ../../src/Contracts
+Reference `..\Contracts\Contracts.csproj` added to the project.
+
+
+```

--- a/Carsties/docker-compose.yml
+++ b/Carsties/docker-compose.yml
@@ -16,4 +16,8 @@ services:
       - 27017:27017
     volumes:
       - /data/db  
-  
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    ports: 
+      - 5672:5672
+      - 15672:15672

--- a/Carsties/src/AuctionService/AuctionService.csproj
+++ b/Carsties/src/AuctionService/AuctionService.csproj
@@ -8,12 +8,18 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.3.4" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Carsties/src/AuctionService/Consumers/AuctionCreatedFaultConsumer.cs
+++ b/Carsties/src/AuctionService/Consumers/AuctionCreatedFaultConsumer.cs
@@ -1,0 +1,25 @@
+using Contracts;
+using MassTransit;
+
+namespace AuctionService.Consumers;
+
+public class AuctionCreatedFaultConsumer: IConsumer<Fault<AuctionCreated>>
+{
+    public async Task Consume(ConsumeContext<Fault<AuctionCreated>> context)
+    {
+        Console.WriteLine("--->> Consuming Faulty Creation");
+
+        var exception = context.Message.Exceptions.First();
+
+        if (exception.ExceptionType == "System.ArgumentException")
+        {
+            Console.WriteLine($"Faulty exception: {exception.Message}");
+            context.Message.Message.Model = "FooBar";
+            await context.Publish(context.Message.Message);
+        }
+        else
+        {
+            Console.WriteLine($"Not an argument exception - update error dashboard somewhere: {exception.Message}");
+        }
+    }
+}

--- a/Carsties/src/AuctionService/Controllers/AuctionsController.cs
+++ b/Carsties/src/AuctionService/Controllers/AuctionsController.cs
@@ -3,6 +3,8 @@ using AuctionService.DTOs;
 using AuctionService.Entities;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
+using Contracts;
+using MassTransit;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -15,11 +17,13 @@ public class AuctionsController: ControllerBase
 {
     private readonly AuctionDbContext _context;
     private readonly IMapper _mapper;
+    private readonly IPublishEndpoint _publishEndpoint;
 
-    public AuctionsController(AuctionDbContext context, IMapper mapper)
+    public AuctionsController(AuctionDbContext context, IMapper mapper, IPublishEndpoint publishEndpoint)
     {
         _context = context;
         _mapper = mapper;
+        _publishEndpoint = publishEndpoint;
     }
 
     [HttpGet]
@@ -60,15 +64,20 @@ public class AuctionsController: ControllerBase
         
         _context.Auctions.Add(auction);
         
+        var newAction = _mapper.Map<AuctionDto>(auction);
+        
+        await _publishEndpoint.Publish(_mapper.Map<AuctionCreated>(newAction));
+        
         var result = await _context.SaveChangesAsync() > 0;
-
+        
         if (!result)
         {
             return BadRequest("Could not save changes to the Database.");
         }
+        
         // 201 created
         return CreatedAtAction(nameof(GetAuctionById), 
-            new {auction.Id}, _mapper.Map<AuctionDto>(auction));
+            new {auction.Id}, newAction);
     }
     
     [HttpPut("{id:guid}")]
@@ -81,6 +90,7 @@ public class AuctionsController: ControllerBase
         {
             return NotFound();
         }
+        
         // TODO: check seller == username
         
         auction.Item.Make = updateAuctionDto.Make ?? auction.Item.Make;
@@ -88,6 +98,8 @@ public class AuctionsController: ControllerBase
         auction.Item.Color = updateAuctionDto.Color ?? auction.Item.Color;
         auction.Item.Mileage = updateAuctionDto.Mileage ?? auction.Item.Mileage;
         auction.Item.Year = updateAuctionDto.Year ?? auction.Item.Year;
+        
+        await _publishEndpoint.Publish(_mapper.Map<AuctionUpdated>(auction));
         
         var result = await _context.SaveChangesAsync() > 0;
         if (!result)
@@ -108,11 +120,12 @@ public class AuctionsController: ControllerBase
 
         _context.Auctions.Remove(auction);
 
+        await _publishEndpoint.Publish<AuctionDeleted>(new { Id = auction.Id.ToString() });
+
         var result = await _context.SaveChangesAsync() > 0;
 
         if (!result) return BadRequest("Could not update Database...");
 
         return Ok();
-
     }
 }

--- a/Carsties/src/AuctionService/Data/AuctionDbContext.cs
+++ b/Carsties/src/AuctionService/Data/AuctionDbContext.cs
@@ -1,4 +1,5 @@
 using AuctionService.Entities;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 
 namespace AuctionService.Data;
@@ -9,4 +10,17 @@ public class AuctionDbContext: DbContext
     {
     }
     public DbSet<Auction> Auctions { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        
+        /*
+         * Using Entity Framework as the outbox storage, it allows applications using AuctionDbContext to safely store
+         * and forward messages while adhering to database transactions, avoiding inconsistencies.
+         */
+        modelBuilder.AddInboxStateEntity();
+        modelBuilder.AddOutboxMessageEntity();
+        modelBuilder.AddOutboxStateEntity();
+    }
 }

--- a/Carsties/src/AuctionService/Data/Migrations/20241224103136_Outbox.Designer.cs
+++ b/Carsties/src/AuctionService/Data/Migrations/20241224103136_Outbox.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AuctionService.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AuctionService.Data.Migrations
 {
     [DbContext(typeof(AuctionDbContext))]
-    partial class AuctionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241224103136_Outbox")]
+    partial class Outbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Carsties/src/AuctionService/Data/Migrations/20241224103136_Outbox.cs
+++ b/Carsties/src/AuctionService/Data/Migrations/20241224103136_Outbox.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace AuctionService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Outbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxState",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsumerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Received = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ReceiveCount = table.Column<int>(type: "integer", nullable: false),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Consumed = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxState", x => x.Id);
+                    table.UniqueConstraint("AK_InboxState_MessageId_ConsumerId", x => new { x.MessageId, x.ConsumerId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxState",
+                columns: table => new
+                {
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxState", x => x.OutboxId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxMessage",
+                columns: table => new
+                {
+                    SequenceNumber = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EnqueueTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    SentTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Headers = table.Column<string>(type: "text", nullable: true),
+                    Properties = table.Column<string>(type: "text", nullable: true),
+                    InboxMessageId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InboxConsumerId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    MessageType = table.Column<string>(type: "text", nullable: false),
+                    Body = table.Column<string>(type: "text", nullable: false),
+                    ConversationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InitiatorId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RequestId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SourceAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    DestinationAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ResponseAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    FaultAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessage", x => x.SequenceNumber);
+                    table.ForeignKey(
+                        name: "FK_OutboxMessage_InboxState_InboxMessageId_InboxConsumerId",
+                        columns: x => new { x.InboxMessageId, x.InboxConsumerId },
+                        principalTable: "InboxState",
+                        principalColumns: new[] { "MessageId", "ConsumerId" });
+                    table.ForeignKey(
+                        name: "FK_OutboxMessage_OutboxState_OutboxId",
+                        column: x => x.OutboxId,
+                        principalTable: "OutboxState",
+                        principalColumn: "OutboxId");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxState_Delivered",
+                table: "InboxState",
+                column: "Delivered");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_EnqueueTime",
+                table: "OutboxMessage",
+                column: "EnqueueTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_ExpirationTime",
+                table: "OutboxMessage",
+                column: "ExpirationTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_InboxMessageId_InboxConsumerId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "InboxMessageId", "InboxConsumerId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_OutboxId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "OutboxId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxState_Created",
+                table: "OutboxState",
+                column: "Created");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxMessage");
+
+            migrationBuilder.DropTable(
+                name: "InboxState");
+
+            migrationBuilder.DropTable(
+                name: "OutboxState");
+        }
+    }
+}

--- a/Carsties/src/AuctionService/Program.cs
+++ b/Carsties/src/AuctionService/Program.cs
@@ -1,4 +1,7 @@
+using AuctionService.Consumers;
 using AuctionService.Data;
+using Contracts;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,6 +16,46 @@ builder.Services.AddDbContext<AuctionDbContext>(options =>
 
 // Provide Automapper as a service. And specify the location of the assemblies containing the profile classes.
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
+
+// Connection for RabbitMq
+builder.Services.AddMassTransit(x =>
+{
+    /*
+     * Configures an Entity Framework Outbox pattern for the specified AuctionDbContext.
+     * The outbox is useful for managing distributed transactions in a reliable and transactional manner.
+     * 1. x Represents a service collection or configuration instance typically used for dependency injection (e.g., IServiceCollection).
+     * 2. AddEntityFrameworkOutbox<TContext>
+     *  2.1. Adds an Entity Framework Outbox for handling messages inside the AuctionDbContext.
+     *  2.2. The type parameter <AuctionDbContext> specifies the DbContext that will use the outbox pattern.
+     *  3.2. Lambda o => { ... }: This is a configuration delegate where additional properties and behaviors of the outbox can be customized.
+     * 3. Configuration within the Delegate:
+     *  3.1. .QueryDelay
+     *      3.1.1. Specifies a delay for the outbox query in order to handle operations such as polling for unprocessed messages.
+     *      3.1.2. Set to 10 seconds in this case (TimeSpan.FromSeconds(10)), meaning queries for unprocessed outbox messages will occur every 10 seconds.
+     * Use Case
+     * 1. The Outbox Pattern ensures atomicity and durability of messages when integrating with different systems
+     *  through events or messages (e.g., in an event-driven system or microservices architecture).
+     * 2. Using Entity Framework as the outbox storage, it allows applications using AuctionDbContext to safely
+     *  store and forward messages while adhering to database transactions, avoiding inconsistencies.
+     */
+    x.AddEntityFrameworkOutbox<AuctionDbContext>(o =>
+    {
+        o.QueryDelay = TimeSpan.FromSeconds(10);
+
+        o.UsePostgres();
+        o.UseBusOutbox();
+    });
+    
+    x.AddConsumersFromNamespaceContaining<AuctionCreatedFaultConsumer>();
+    
+    x.SetEndpointNameFormatter(new KebabCaseEndpointNameFormatter("auction", false));
+    
+    x.UsingRabbitMq((context, cfg) =>
+    {
+        
+        cfg.ConfigureEndpoints(context);
+    });
+});
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 // builder.Services.AddEndpointsApiExplorer();

--- a/Carsties/src/AuctionService/RequestHelpers/MappingProfiles.cs
+++ b/Carsties/src/AuctionService/RequestHelpers/MappingProfiles.cs
@@ -1,6 +1,7 @@
 using AuctionService.DTOs;
 using AuctionService.Entities;
 using AutoMapper;
+using Contracts;
 
 namespace AuctionService.RequestHelpers;
 
@@ -22,6 +23,8 @@ public class MappingProfiles: Profile
         CreateMap<CreateAuctionDto, Auction>()
             .ForMember(d => d.Item, o => o.MapFrom(s => s));
         CreateMap<CreateAuctionDto, Item>();
-        
+        CreateMap<AuctionDto, AuctionCreated>();
+        CreateMap<Auction, AuctionUpdated>().IncludeMembers(x => x.Item);
+        CreateMap<Item, AuctionUpdated>();
     }
 }

--- a/Carsties/src/Contracts/AuctionCreated.cs
+++ b/Carsties/src/Contracts/AuctionCreated.cs
@@ -1,0 +1,37 @@
+namespace Contracts;
+
+public class AuctionCreated
+{
+    public Guid Id { get; set; }
+
+    public int ReservePrice { get; set; }
+    
+    public string Seller { get; set; }
+    
+    public string Winner { get; set; }
+
+    public int SoldAmount { get; set; }
+    
+    public int CurrentHighBid   { get; set; }
+    
+    public DateTime CreatedAt { get; set; }
+    
+    public DateTime UpdatedAt { get; set; }
+    
+    public DateTime AuctionEnd { get; set; }
+
+    public string Status { get; set; }
+    
+    public string Make { get; set; }
+    
+    public string Model { get; set; }
+    
+    public int Year { get; set; }
+    
+    public string Color { get; set; }
+
+    public int Mileage { get; set; }
+
+    public string ImageUrl { get; set; }
+
+}

--- a/Carsties/src/Contracts/AuctionDeleted.cs
+++ b/Carsties/src/Contracts/AuctionDeleted.cs
@@ -1,0 +1,6 @@
+namespace Contracts;
+
+public class AuctionDeleted
+{
+    public string Id { get; set; }
+}

--- a/Carsties/src/Contracts/AuctionUpdated.cs
+++ b/Carsties/src/Contracts/AuctionUpdated.cs
@@ -1,0 +1,16 @@
+namespace Contracts;
+
+public class AuctionUpdated
+{
+    public string Id { get; set; }
+    
+    public string Make { get; set; }
+    
+    public string Model { get; set; }
+    
+    public int Year { get; set; }
+    
+    public string Color { get; set; }
+
+    public int Mileage { get; set; }
+}

--- a/Carsties/src/Contracts/Contracts.csproj
+++ b/Carsties/src/Contracts/Contracts.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Carsties/src/SearchService/Consumers/AuctionCreatedConsumer.cs
+++ b/Carsties/src/SearchService/Consumers/AuctionCreatedConsumer.cs
@@ -1,0 +1,28 @@
+using AutoMapper;
+using Contracts;
+using MassTransit;
+using MongoDB.Entities;
+using SearchService.Models;
+
+namespace SearchService.Consumers;
+
+public class AuctionCreatedConsumer: IConsumer<AuctionCreated>
+{
+    private readonly IMapper _mapper;
+
+    public AuctionCreatedConsumer(IMapper mapper)
+    {
+        _mapper = mapper;
+    }
+    
+    public async Task Consume(ConsumeContext<AuctionCreated> context)
+    {
+        Console.WriteLine("===> Consuming Auction Created "+ context.Message.Id);
+        
+        var item = _mapper.Map<Item>(context.Message);
+
+        if (item.Model == "Foo") throw new ArgumentException("Cannot sell cars with name of Foo");
+
+        await item.SaveAsync();
+    }
+}

--- a/Carsties/src/SearchService/Consumers/AuctionDeletedConsumer.cs
+++ b/Carsties/src/SearchService/Consumers/AuctionDeletedConsumer.cs
@@ -1,0 +1,29 @@
+using AutoMapper;
+using Contracts;
+using MassTransit;
+using MongoDB.Entities;
+using SearchService.Models;
+
+namespace SearchService.Consumers;
+
+public class AuctionDeletedConsumer: IConsumer<AuctionDeleted> 
+{
+    private readonly IMapper _mapper;
+
+    public AuctionDeletedConsumer(IMapper mapper)
+    {
+        _mapper = mapper;
+    }
+
+    public async Task Consume(ConsumeContext<AuctionDeleted> context)
+    {
+        Console.WriteLine($"---> Consuming AuctionDeleted: {context.Message.Id}");
+
+        var result = await DB.DeleteAsync<Item>(context.Message.Id);
+
+        if (!result.IsAcknowledged)
+        {
+            throw new MessageException(typeof(AuctionDeleted), $"Problem Deleting Auction, Could not delete auction record {context.Message.Id}");
+        }
+    }
+}

--- a/Carsties/src/SearchService/Consumers/AuctionUpdatedConsumer.cs
+++ b/Carsties/src/SearchService/Consumers/AuctionUpdatedConsumer.cs
@@ -1,0 +1,42 @@
+using AutoMapper;
+using Contracts;
+using MassTransit;
+using MongoDB.Entities;
+using SearchService.Models;
+
+namespace SearchService.Consumers;
+
+public class AuctionUpdatedConsumer: IConsumer<AuctionUpdated>
+{
+    private readonly IMapper _mapper;
+
+    public AuctionUpdatedConsumer(IMapper mapper)
+    {
+        _mapper = mapper;
+    }
+
+
+    public async Task Consume(ConsumeContext<AuctionUpdated> context)
+    {
+        Console.WriteLine($"Auction updated: {context.Message.Id}");
+        
+        var item = _mapper.Map<Item>(context.Message);
+     
+        var result = await DB.Update<Item>()
+            .Match(a => a.ID == context.Message.Id)
+            .ModifyOnly(x => new
+            {
+                x.Color,
+                x.Make,
+                x.Model,
+                x.Year,
+                x.Mileage
+            }, item)
+            .ExecuteAsync();
+
+        if (!result.IsAcknowledged)
+        {
+            throw new MessageException(typeof(AuctionUpdated), $"Update of auction failed updating Mongodb: {context.Message.Id}");
+        }
+    }
+}

--- a/Carsties/src/SearchService/Program.cs
+++ b/Carsties/src/SearchService/Program.cs
@@ -1,6 +1,9 @@
 using System.Net;
+using Contracts;
+using MassTransit;
 using Polly;
 using Polly.Extensions.Http;
+using SearchService.Consumers;
 using SearchService.Data;
 using SearchService.Services;
 
@@ -10,7 +13,29 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 
+builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
+
 builder.Services.AddHttpClient<AuctionSvcHttpClient>().AddPolicyHandler(GetPolicy());
+
+// Connection for RabbitMq
+builder.Services.AddMassTransit(x =>
+{
+    x.AddConsumersFromNamespaceContaining<AuctionCreatedConsumer>();
+    
+    x.SetEndpointNameFormatter(new KebabCaseEndpointNameFormatter("search", false));
+    
+    x.UsingRabbitMq((context, cfg) =>
+    {
+        cfg.ReceiveEndpoint("search-auction-created", e =>
+        {
+            e.UseMessageRetry(r => r.Interval(5, TimeSpan.FromSeconds(5)));
+            
+            e.ConfigureConsumer<AuctionCreatedConsumer>(context);
+        });
+        
+        cfg.ConfigureEndpoints(context);
+    });
+});
 
 var app = builder.Build();
 

--- a/Carsties/src/SearchService/RequestHelpers/MappingProfiles.cs
+++ b/Carsties/src/SearchService/RequestHelpers/MappingProfiles.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Contracts;
+using SearchService.Models;
+
+namespace SearchService.RequestHelpers;
+
+public class MappingProfiles: Profile
+{
+    public MappingProfiles()
+    {
+        CreateMap<AuctionCreated, Item>();
+        CreateMap<AuctionUpdated, Item>();
+    }
+}

--- a/Carsties/src/SearchService/SearchService.csproj
+++ b/Carsties/src/SearchService/SearchService.csproj
@@ -9,9 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.4" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.11" />
     <PackageReference Include="MongoDB.Entities" Version="24.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Introduced `AuctionCreated`, `AuctionUpdated`, and `AuctionDeleted` events in Contracts and implemented respective consumers in `SearchService`. Integrated MassTransit with RabbitMQ and configured the Outbox pattern for reliable message delivery in `AuctionService`. Extended mappings and controller logic to publish these events on auction lifecycle changes, ensuring event-driven behavior across services.